### PR TITLE
Updating openshift-client to 4.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 \.vscode/settings\.json
 
 \.vscode/
+
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,8 @@
 		</dependency>
 		<dependency>
 			<groupId>io.fabric8</groupId>
-			<artifactId>spring-cloud-starter-kubernetes</artifactId>
-			<version>0.0.16</version>
-		</dependency>
-		<dependency>
-			<groupId>io.fabric8</groupId>
 			<artifactId>openshift-client</artifactId>
-			<version>1.4.10</version>
+			<version>4.6.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/openshift/wildwest/controllers/GameController.java
+++ b/src/main/java/com/openshift/wildwest/controllers/GameController.java
@@ -67,12 +67,5 @@ public class GameController {
 		}
 		return currentMode;
 	}
-	/*
-	private PlatformObject getRandomObject() {
-		PlatformObject randomObject = new PlatformObject();
-		
-		return randomObject;
-	}
-	*/
 
 }

--- a/src/main/java/com/openshift/wildwest/helpers/PlatformObjectHelper.java
+++ b/src/main/java/com/openshift/wildwest/helpers/PlatformObjectHelper.java
@@ -7,7 +7,6 @@ import com.openshift.wildwest.models.PlatformObject;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.DeploymentConfig;
@@ -27,9 +26,6 @@ public class PlatformObjectHelper {
 
 		ArrayList<PlatformObject> platformObjects = new ArrayList<>();
 		platformObjects.addAll(this.getPods());
-		//platformObjects.addAll(this.getBuilds());
-		//platformObjects.addAll(this.getDeploymentConfigs());
-		//platformObjects.addAll(this.getBuildConfigs());
 		platformObjects.addAll(this.getPVs());
 		platformObjects.addAll(this.getServices());
 		platformObjects.addAll(this.getRoutes());


### PR DESCRIPTION
This pull request updates the `openshift-client` dependency to `4.6.1` and removes the `spring-cloud-starter-kubernetes` dependency. This will help make the component work with OpenShift 4.2. It also removes commented out code.